### PR TITLE
Set schema after creating migrations table

### DIFF
--- a/django_tenants/migration_executors/base.py
+++ b/django_tenants/migration_executors/base.py
@@ -43,6 +43,10 @@ def run_migrations(args, options, executor_codename, schema_name, tenant_type=''
     # table in the public schema gets picked and no migrations are applied
     migration_recorder = MigrationRecorder(connection)
     migration_recorder.ensure_schema()
+    
+    # As creating the django_migrations table does not restore the search path, it's necessary
+    # to reset it to work with TENANT_LIMIT_SET_CALLS=True.
+    connection.set_schema(schema_name, tenant_type=tenant_type)
 
     stdout = OutputWrapper(sys.stdout)
     stdout.style_func = style_func


### PR DESCRIPTION
This commit adds a duplicate "set_schema" after the verification for the creation of the django_migrations model. This is necessary for the migrate_schemas command to work properly when TENANT_LIMIT_SET_CALLS is True as the cursor for the transaction to create the migrations table would not set the search path back to the tenant.

Checking the existence of the migrations table does not have such an effect as Introspection is wrapped to use tenant-aware cursors. This is not possible however with Schemas; where the table is created.